### PR TITLE
fix: [lean4web] standardise URI for missmatching client/server OS

### DIFF
--- a/vscode-lean4/src/utils/exturi.ts
+++ b/vscode-lean4/src/utils/exturi.ts
@@ -10,6 +10,8 @@ export class FileUri {
     fsPath: string
 
     constructor(fsPath: string) {
+        // TODO: Is this robust on Windows???
+        fsPath = fsPath.replaceAll('\\', '/')
         this.scheme = 'file'
         this.fsPath = fsPath
     }


### PR DESCRIPTION
This is probably not the right solution to be added to the VSCode extension. After all, the extension never has the problem that there are two different OS in play.

This fixes the a bug that a Windows client would send a `FileURI` of the form `\\project\\test.lean` which UNIX systems can't parse.

The other direction is fine as Windows can very well find `/project/test.lean`.